### PR TITLE
CI: Improved test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,66 @@
 version: 2
-
 jobs:
-  build:
+  test:
     docker:
-      - image: rustlang/rust:nightly
+      - image: rust:1.31
     steps:
       - checkout
-      - run: cargo build
+      - restore_cache:
+          keys:
+            - v1-cargo-cache-{{ arch }}-{{ .Branch }}
+            - v1-cargo-cache-{{ arch }}
+      - run:
+          name: Show versions
+          command: rustc --version && cargo --version
+      - run:
+          name: Build
+          command: cargo build
+      - run:
+          name: Run tests
+          command: cargo test
+      - save_cache:
+          key: v1-cargo-cache-{{ arch }}-{{ .Branch }}
+          paths:
+            - target
+            - /usr/local/cargo
+      - save_cache:
+          key: v1-cargo-cache-{{ arch }}
+          paths:
+            - target
+            - /usr/local/cargo
+  lint:
+    docker:
+      - image: rust:1.31
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-cargo-lint-cache
+      - run: rustup component add clippy
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+      - save_cache:
+          key: v1-cargo-lint-cache
+          paths:
+            - /usr/local/cargo
+
+workflows:
+  version: 2
+
+  # Build on push
+  on_push:
+    jobs:
+      - test
+      - lint
+
+  # Build master every week on Monday at 04:00 am
+  weekly:
+    triggers:
+      - schedule:
+          cron: "0 4 * * 1"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - test
+      - lint


### PR DESCRIPTION
Fails because the `lpc11uxx` 0.3 crate is not yet released and still requires nightly.

See https://github.com/lpc-rs/lpc-pac/pull/6